### PR TITLE
feat: switch to conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,17 +76,17 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - env:
-  #         NEEDS: ${{ toJSON(needs) }}     
+  #         NEEDS: ${{ toJSON(needs) }}
   #       run: |
   #         echo "$NEEDS"
-    
+
   # test-needs-skipped:
   #   needs: test
   #   if: always() && github.event.inputs.release == 'true' && needs.test.result == 'skipped'
   #   runs-on: ubuntu-latest
   #   steps:
   #     - env:
-  #         NEEDS: ${{ toJSON(needs) }}     
+  #         NEEDS: ${{ toJSON(needs) }}
   #       run: |
   #         echo "$NEEDS"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Features <!-- omit in toc -->
 
-- Uses the [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) to generate [release notes](https://github.com/semantic-release/release-notes-generator), [changelogs](https://github.com/semantic-release/changelog) and [determine the version for new releases](https://github.com/semantic-release/commit-analyzer).
+- Uses [Conventional Commits](https://www.conventionalcommits.org/) to generate [release notes](https://github.com/semantic-release/release-notes-generator), [changelogs](https://github.com/semantic-release/changelog) and [determine the version for new releases](https://github.com/semantic-release/commit-analyzer).
 - [Creates or updates a CHANGELOG.md file](https://github.com/semantic-release/changelog).
 - [Publishes to npm](https://github.com/semantic-release/npm).
 - [Creates a new release on GitHub](https://github.com/semantic-release/github)

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 // @ts-check
 /* eslint-disable no-template-curly-in-string */
 
+const preset = 'conventionalcommits'
+
 /**
  * @type {import('semantic-release').Options}
  **/
 const options = {
   plugins: [
-    '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/commit-analyzer', { preset }],
+    ['@semantic-release/release-notes-generator', { preset }],
     [
       '@semantic-release/changelog',
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
+        "conventional-changelog-conventionalcommits": "^5.0.0",
         "semantic-release": "^19.0.3",
         "semantic-release-license": "^1.0.3"
       },
@@ -1199,6 +1200,19 @@
       "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
       "dependencies": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       },
       "engines": {
@@ -9045,6 +9059,16 @@
       "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
       "requires": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
+    "conventional-changelog-conventionalcommits": "^5.0.0",
     "semantic-release": "^19.0.3",
     "semantic-release-license": "^1.0.3"
   },


### PR DESCRIPTION
BREAKING CHANGE:  this preset used the angular commit convention previously, from now on it's conventional commits so we match our commitlint and other semantic release setups.