### PR TITLE
feat: allow release name template through env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ All notable changes to this project will be documented in this file. See
         releasedLabels: false,
         // @TODO remove this before releasing on main
         successComment: false,
+        // Allow customizing the release name via an environment variable
+        ...(process.env.SR_RELEASE_NAME_TEMPLATE && {
+          releaseNameTemplate: process.env.SR_RELEASE_NAME_TEMPLATE,
+        }),
       },
     ],
   ],

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const preset = 'conventionalcommits'
  **/
 const options = {
   plugins: [
-    ['@semantic-release/commit-analyzer', {preset}],
-    ['@semantic-release/release-notes-generator', {preset}],
+    ['@semantic-release/commit-analyzer', { preset }],
+    ['@semantic-release/release-notes-generator', { preset }],
     [
       '@semantic-release/changelog',
       {
@@ -18,20 +18,20 @@ const options = {
 # 📓 Changelog
 
 All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.`,
-      },
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.`
+      }
     ],
     [
       '@semantic-release/exec',
       {
-        prepareCmd: 'npx -y prettier --write CHANGELOG.md',
-      },
+        prepareCmd: 'npx -y prettier --write CHANGELOG.md'
+      }
     ],
     [
       '@semantic-release/npm',
       {
-        tarballDir: '.semantic-release',
-      },
+        tarballDir: '.semantic-release'
+      }
     ],
     'semantic-release-license',
     [
@@ -43,10 +43,10 @@ All notable changes to this project will be documented in this file. See
           'package-lock.json',
           'package.json',
           'pnpm-lock.yaml',
-          'yarn.lock',
+          'yarn.lock'
         ],
-        message: 'chore(release): ${nextRelease.version} [skip ci]',
-      },
+        message: 'chore(release): ${nextRelease.version} [skip ci]'
+      }
     ],
     [
       '@semantic-release/github',
@@ -59,11 +59,11 @@ All notable changes to this project will be documented in this file. See
         successComment: false,
         // Allow customizing the release name via an environment variable
         ...(process.env.SR_RELEASE_NAME_TEMPLATE && {
-          releaseNameTemplate: process.env.SR_RELEASE_NAME_TEMPLATE,
-        }),
-      },
-    ],
-  ],
+          releaseNameTemplate: process.env.SR_RELEASE_NAME_TEMPLATE
+        })
+      }
+    ]
+  ]
 }
 
 module.exports = options


### PR DESCRIPTION
### Description

Have a use case where I want to override the release title to use `nextRelease.version` instead of `nextRelease.name`. Would be ideal not to have to eject from the preset just to do so.

CI linter complained about not using `standard` for formatting - not sure how that has passed previously, but this also does a `standard --fix`.

### What to review

Are there better ways of doing this?

### Testing

Untested, but change seems fairly trivial?